### PR TITLE
Correct solution of the task of creating a "task API" with laravel 11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 			"extensions": [
 				"bmewburn.vscode-intelephense-client",
                 "xdebug.php-debug",
-				"rangav.vscode-thunder-client"
+				"rangav.vscode-thunder-client",
+				"sourcegraph.cody-ai"
 				// "mikestead.dotenv",
 				// "amiralizadeh9480.laravel-extra-intellisense",
 				// "ryannaddy.laravel-artisan",

--- a/app/Api/V1/Actions/CreateProjectAction.php
+++ b/app/Api/V1/Actions/CreateProjectAction.php
@@ -8,8 +8,6 @@ class CreateProjectAction
 {
     /**
      * Create a new project
-     * 
-     * @return Project
      */
     public function execute(array $projectData): Project
     {

--- a/app/Api/V1/Actions/DeleteProjectAction.php
+++ b/app/Api/V1/Actions/DeleteProjectAction.php
@@ -8,10 +8,8 @@ class DeleteProjectAction
 {
     /**
      * Delete a project.
-     * 
-     * @return bool|null
      */
-    public function execute(Project $project): bool|null
+    public function execute(Project $project): ?bool
     {
         // There could be a massive logic for deleting a project.
         return $project->delete();

--- a/app/Api/V1/Actions/UpdateProjectAction.php
+++ b/app/Api/V1/Actions/UpdateProjectAction.php
@@ -8,7 +8,7 @@ class UpdateProjectAction
 {
     /**
      * Update an existing project.
-     * 
+     *
      * @return Project
      */
     public function execute(Project $project, array $projectData): bool

--- a/app/Api/V1/Actions/UpdateTaskAction.php
+++ b/app/Api/V1/Actions/UpdateTaskAction.php
@@ -8,7 +8,7 @@ class UpdateTaskAction
 {
     /**
      * Update an existing task.
-     * 
+     *
      * @return Task
      */
     public function execute(Task $task, array $taskData): bool

--- a/app/Enums/Auth/Token/ProjectTokenEnum.php
+++ b/app/Enums/Auth/Token/ProjectTokenEnum.php
@@ -16,11 +16,9 @@ enum ProjectTokenEnum: string
 
     /**
      * Return a token ablity representation.
-     * 
-     * @return string 
      */
     public function toAbility(): string
     {
-        return 'ability:' . $this->value;
+        return 'ability:'.$this->value;
     }
 }

--- a/app/Enums/Auth/Token/TaskTokenEnum.php
+++ b/app/Enums/Auth/Token/TaskTokenEnum.php
@@ -3,9 +3,10 @@
 namespace App\Enums\Auth\Token;
 
 /**
- * Implement a token. 
+ * Implement a token.
  */
-enum TaskTokenEnum: string {
+enum TaskTokenEnum: string
+{
     public const NAME = 'task-token';
 
     case List = 'task-list';
@@ -18,11 +19,9 @@ enum TaskTokenEnum: string {
 
     /**
      * Return a token ablity representation.
-     * 
-     * @return string 
      */
     public function toAbility(): string
     {
-        return 'ability:' . $this->value;
+        return 'ability:'.$this->value;
     }
 }

--- a/app/Enums/Auth/Token/UserTokenEnum.php
+++ b/app/Enums/Auth/Token/UserTokenEnum.php
@@ -10,11 +10,9 @@ enum UserTokenEnum: string
 
     /**
      * Return a token ablity representation.
-     * 
-     * @return string 
      */
     public function toAbility(): string
     {
-        return 'ability:' . $this->value;
+        return 'ability:'.$this->value;
     }
 }

--- a/app/Enums/StateEnum.php
+++ b/app/Enums/StateEnum.php
@@ -2,7 +2,8 @@
 
 namespace App\Enums;
 
-enum StateEnum: string {
+enum StateEnum: string
+{
     case Todo = 'todo';
     case InProgess = 'in_progress';
     case Done = 'done';

--- a/app/Events/TaskUpdating.php
+++ b/app/Events/TaskUpdating.php
@@ -2,10 +2,10 @@
 
 namespace App\Events;
 
+use App\Models\Task;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
-use App\Models\Task;
 
 class TaskUpdating
 {

--- a/app/Http/Controllers/Api/V1/Projects/ProjectIndexController.php
+++ b/app/Http/Controllers/Api/V1/Projects/ProjectIndexController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Projects;
 
-use App\Http\Resources\V1\ProjectResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\ProjectResource;
 use App\Models\Project;
 
 class ProjectIndexController extends Controller

--- a/app/Http/Controllers/Api/V1/Projects/ProjectShowController.php
+++ b/app/Http/Controllers/Api/V1/Projects/ProjectShowController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Projects;
 
-use App\Http\Resources\V1\ProjectResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\ProjectResource;
 use App\Models\Project;
 
 class ProjectShowController extends Controller

--- a/app/Http/Controllers/Api/V1/Projects/ProjectStoreController.php
+++ b/app/Http/Controllers/Api/V1/Projects/ProjectStoreController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api\V1\Projects;
 
-use App\Http\Requests\V1\StoreProjectRequest;
 use App\Api\V1\Actions\CreateProjectAction;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\V1\StoreProjectRequest;
 
 class ProjectStoreController extends Controller
 {

--- a/app/Http/Controllers/Api/V1/Projects/ProjectTasksController.php
+++ b/app/Http/Controllers/Api/V1/Projects/ProjectTasksController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Projects;
 
-use App\Http\Resources\V1\ProjectTasksResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\ProjectTasksResource;
 use App\Models\Project;
 
 class ProjectTasksController extends Controller

--- a/app/Http/Controllers/Api/V1/Projects/ProjectUpdateController.php
+++ b/app/Http/Controllers/Api/V1/Projects/ProjectUpdateController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api\V1\Projects;
 
-use App\Http\Requests\V1\StoreProjectRequest;
 use App\Api\V1\Actions\UpdateProjectAction;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\V1\StoreProjectRequest;
 use App\Models\Project;
 
 class ProjectUpdateController extends Controller

--- a/app/Http/Controllers/Api/V1/TaskController.php
+++ b/app/Http/Controllers/Api/V1/TaskController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Http\Requests\V1\UpdateTaskRequest;
-use App\Http\Requests\V1\StoreTaskRequest;
-use App\Http\Resources\V1\TaskResource;
-use App\Http\Controllers\Controller;
 use App\Enums\StateEnum;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V1\StoreTaskRequest;
+use App\Http\Requests\V1\UpdateTaskRequest;
+use App\Http\Resources\V1\TaskResource;
 use App\Models\Task;
 
 class TaskController extends Controller
@@ -53,6 +53,7 @@ class TaskController extends Controller
     public function destroy(Task $task)
     {
         $task->delete();
+
         // Return 204 - No content.
         return response()->noContent();
     }

--- a/app/Http/Controllers/Api/V1/Tasks/TaskIndexController.php
+++ b/app/Http/Controllers/Api/V1/Tasks/TaskIndexController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Tasks;
 
-use App\Http\Resources\V1\TaskIndexResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\TaskIndexResource;
 use App\Models\Task;
 
 class TaskIndexController extends Controller

--- a/app/Http/Controllers/Api/V1/Tasks/TaskOverdueController.php
+++ b/app/Http/Controllers/Api/V1/Tasks/TaskOverdueController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\V1\Tasks;
 
-use App\Http\Resources\V1\TaskResource;
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Http\Resources\V1\TaskResource;
 use App\Models\Task;
+use Illuminate\Http\Request;
 
 class TaskOverdueController extends Controller
 {

--- a/app/Http/Controllers/Api/V1/Tasks/TaskProjectsController.php
+++ b/app/Http/Controllers/Api/V1/Tasks/TaskProjectsController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Tasks;
 
-use App\Http\Resources\V1\TaskResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\TaskResource;
 use App\Models\Task;
 
 class TaskProjectsController extends Controller

--- a/app/Http/Controllers/Api/V1/Tasks/TaskUpdateController.php
+++ b/app/Http/Controllers/Api/V1/Tasks/TaskUpdateController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api\V1\Tasks;
 
-use App\Http\Requests\V1\PatchTaskRequest;
 use App\Api\V1\Actions\UpdateTaskAction;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\V1\PatchTaskRequest;
 use App\Models\Task;
 
 class TaskUpdateController extends Controller

--- a/app/Http/Controllers/Api/V1/Users/UserTasksController.php
+++ b/app/Http/Controllers/Api/V1/Users/UserTasksController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1\Users;
 
-use App\Http\Resources\V1\UserTasksResource;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\UserTasksResource;
 use App\Models\User;
 
 class UserTasksController extends Controller

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,23 +2,22 @@
 
 namespace App\Http\Controllers;
 
-use Symfony\Component\HttpFoundation\Response;
 use App\Enums\Auth\Token\ProjectTokenEnum;
 use App\Enums\Auth\Token\TaskTokenEnum;
 use App\Enums\Auth\Token\UserTokenEnum;
+use App\Models\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Laravel\Sanctum\NewAccessToken;
-use Illuminate\Http\Request;
-use App\Models\User;
+use Symfony\Component\HttpFoundation\Response;
 
 class AuthController extends Controller
 {
     /**
      * Log in an user.
-     * 
-     * @param Request $request The given request.
-     * 
-     * @return void 
+     *
+     * @param  Request  $request  The given request.
+     * @return void
      */
     public function login(Request $request)
     {
@@ -29,14 +28,14 @@ class AuthController extends Controller
 
         $user = User::where('email', $request->email)->first();
 
-        if (!$user || !Hash::check($request->password, $user->password)) {
+        if (! $user || ! Hash::check($request->password, $user->password)) {
             return response()->json(
                 ['message' => 'The provided credentials are incorrect.'],
                 Response::HTTP_UNAUTHORIZED
             );
         }
 
-        $accessToken = ($user->isAdmin()) 
+        $accessToken = ($user->isAdmin())
             ? $this->createAdminToken($user)
             : $this->createUserToken($user);
 
@@ -47,29 +46,26 @@ class AuthController extends Controller
     }
 
     /**
-     * Create a new token for a user with the 
+     * Create a new token for a user with the
      * role ADIMINISTATOR.
-     * 
-     * @return \Laravel\Sanctum\NewAccessToken
      */
     private function createAdminToken($user): NewAccessToken
     {
         return $user->createToken(
             'admin-token',
             array_map(
-                fn($tokenEnum) => $tokenEnum->value, 
+                fn ($tokenEnum) => $tokenEnum->value,
                 array_merge(
-                    TaskTokenEnum::cases(), 
+                    TaskTokenEnum::cases(),
                     ProjectTokenEnum::cases(),
                     UserTokenEnum::cases()
                 )
             )
         );
     }
+
     /**
      * Create a new token for a user with the role USER.
-     * 
-     * @return \Laravel\Sanctum\NewAccessToken
      */
     private function createUserToken($user): NewAccessToken
     {

--- a/app/Http/Middleware/AlwaysAcceptJson.php
+++ b/app/Http/Middleware/AlwaysAcceptJson.php
@@ -16,7 +16,7 @@ class AlwaysAcceptJson
     public function handle(Request $request, Closure $next): Response
     {
         $request->headers->set('Accept', 'application/json');
-    
+
         return $next($request);
     }
 }

--- a/app/Http/Middleware/CheckTaskUpdateAuthorization.php
+++ b/app/Http/Middleware/CheckTaskUpdateAuthorization.php
@@ -2,16 +2,16 @@
 
 namespace App\Http\Middleware;
 
-use Symfony\Component\HttpFoundation\Response;
 use App\Events\TaskUpdating;
-use Illuminate\Http\Request;
 use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class CheckTaskUpdateAuthorization
 {
     /**
      * Send this message if deadline has expired.
-     * 
+     *
      * @const
      */
     const DEADLINE_HAS_EXPIRED = 'The deadline of the task has expired';
@@ -19,10 +19,10 @@ class CheckTaskUpdateAuthorization
     /**
      * Send this message if admin tries to access tasks the have
      * no expired deadline.
-     * 
+     *
      * @const
      */
-    const ACCESS_TO_NOT_EXPIRED_DEADLINES_FORBIDDEN = 
+    const ACCESS_TO_NOT_EXPIRED_DEADLINES_FORBIDDEN =
         'You can not access task with deadlines that have not expired.';
 
     /**
@@ -32,13 +32,13 @@ class CheckTaskUpdateAuthorization
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (!$request->routeIs('tasks.update')) {
+        if (! $request->routeIs('tasks.update')) {
             return $next($request);
         }
 
         $task = $request->route('task');
 
-        if (!$task) {
+        if (! $task) {
             return $next($request);
         }
 
@@ -47,8 +47,8 @@ class CheckTaskUpdateAuthorization
         $isOwner = $task->user_id == auth()->id();
 
         abort_if(
-            $isAdmin && !$isOverdue, 
-            Response::HTTP_FORBIDDEN, 
+            $isAdmin && ! $isOverdue,
+            Response::HTTP_FORBIDDEN,
             self::ACCESS_TO_NOT_EXPIRED_DEADLINES_FORBIDDEN
         );
 
@@ -56,7 +56,7 @@ class CheckTaskUpdateAuthorization
 
         abort_if(
             $isOverdue && $isOwner,
-            Response::HTTP_UNPROCESSABLE_ENTITY, 
+            Response::HTTP_UNPROCESSABLE_ENTITY,
             self::DEADLINE_HAS_EXPIRED
         );
 

--- a/app/Http/Middleware/CheckTaskUpdateAuthorization.php
+++ b/app/Http/Middleware/CheckTaskUpdateAuthorization.php
@@ -48,13 +48,14 @@ class CheckTaskUpdateAuthorization
 
         if ($isAdmin) {
             TaskUpdating::dispatchIf($isOverdue, $task);
-            
+
             // Only abort if the task is not overdue and the admin is not the owner.
             abort_if(
                 ! $isOverdue && ! $isOwner,
                 Response::HTTP_FORBIDDEN,
                 self::DEADLINE_HAS_EXPIRED
-            );  
+            );
+
             return $next($request);
         }
 

--- a/app/Http/Requests/V1/StoreTaskRequest.php
+++ b/app/Http/Requests/V1/StoreTaskRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\V1;
 
+use App\Enums\StateEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Enums\StateEnum;
 
 class StoreTaskRequest extends FormRequest
 {

--- a/app/Http/Requests/V1/UpdateTaskRequest.php
+++ b/app/Http/Requests/V1/UpdateTaskRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests\V1;
 
+use App\Enums\StateEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use App\Enums\StateEnum;
 
 class UpdateTaskRequest extends FormRequest
 {
@@ -28,8 +28,8 @@ class UpdateTaskRequest extends FormRequest
             'description' => 'sometimes|required',
             'state' => [
                 'sometimes',
-                'required', 
-                Rule::in(StateEnum::InProgess->value, StateEnum::Done->value)
+                'required',
+                Rule::in(StateEnum::InProgess->value, StateEnum::Done->value),
             ],
             'project_id' => 'sometimes|exists:projects,id',
             'deadline' => 'sometimes|required|date|after:today',

--- a/app/Http/Resources/V1/ProjectResource.php
+++ b/app/Http/Resources/V1/ProjectResource.php
@@ -17,6 +17,6 @@ class ProjectResource extends JsonResource
         return [
             'id' => $this->id,
             'title' => $this->title,
-        ]; 
+        ];
     }
 }

--- a/app/Http/Resources/V1/TaskIndexResource.php
+++ b/app/Http/Resources/V1/TaskIndexResource.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Resources\V1;
 
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
 
 class TaskIndexResource extends JsonResource

--- a/app/Http/Resources/V1/TaskResource.php
+++ b/app/Http/Resources/V1/TaskResource.php
@@ -21,6 +21,6 @@ class TaskResource extends JsonResource
             'state' => $this->state,
             'project_id' => $this->project_id ?? 0,
             'deadline' => $this->deadline ?? '',
-        ]; 
+        ];
     }
 }

--- a/app/Listeners/TaskUpdatingListener.php
+++ b/app/Listeners/TaskUpdatingListener.php
@@ -2,9 +2,9 @@
 
 namespace App\Listeners;
 
-use Illuminate\Support\Facades\Mail;
-use App\Mail\DeadlineBreachedEmail;
 use App\Events\TaskUpdating;
+use App\Mail\DeadlineBreachedEmail;
+use Illuminate\Support\Facades\Mail;
 
 class TaskUpdatingListener
 {
@@ -18,10 +18,10 @@ class TaskUpdatingListener
 
     /**
      * Handle the event.
-     * 
+     *
      * @return mixed
      */
-    public function handle(TaskUpdating $event) 
+    public function handle(TaskUpdating $event)
     {
         // Task has no deadline or deadline is not breached.
         if ($event->task->deadline === null || now() < $event->task->deadline) {
@@ -30,10 +30,10 @@ class TaskUpdatingListener
 
         $user = $event->task->user;
         // Log::info('Mail is sent to user because the deadline is expired');
-        
+
         Mail::to($user->email)->send(
             new DeadlineBreachedEmail(
-                $user->name, 
+                $user->name,
                 $event->task->title
             )
         );

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -3,8 +3,8 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Project extends Model
 {
@@ -21,10 +21,9 @@ class Project extends Model
 
     /**
      * Define the relationship with the User model.
-     * 
-     * @return HasMany
      */
-    public function tasks(): HasMany {
+    public function tasks(): HasMany
+    {
         return $this->hasMany(Task::class);
-    }   
+    }
 }

--- a/app/Models/Scopes/CreatorScope.php
+++ b/app/Models/Scopes/CreatorScope.php
@@ -22,7 +22,7 @@ class CreatorScope implements Scope
         if (auth()->user()->isAdmin()) {
             return;
         }
-        
+
         // Allow only the owner of the task to access it.
         $builder->where('user_id', auth()->id());
     }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -25,7 +25,6 @@ class Task extends Model
         'title',
         'description',
         'state',
-        'project_id',
         'deadline',
     ];
 

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -2,14 +2,14 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Attributes\ScopedBy;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use App\Models\Scopes\CreatorScope;
 use App\Enums\Auth\Roles\Role;
 use App\Enums\StateEnum;
+use App\Models\Scopes\CreatorScope;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 #[ScopedBy([CreatorScope::class])]
 class Task extends Model
@@ -61,11 +61,8 @@ class Task extends Model
         ];
     }
 
-
     /**
      * Define the relationship with the User model.
-     * 
-     * @return BelongsTo
      */
     public function user(): BelongsTo
     {
@@ -74,8 +71,6 @@ class Task extends Model
 
     /**
      * Define the relationship with the Project model.
-     * 
-     * @return BelongsTo
      */
     public function project(): BelongsTo
     {
@@ -84,9 +79,6 @@ class Task extends Model
 
     /**
      * Scope a query to only include overdue tasks.
-     * 
-     * @param Builder $query 
-     * @return void 
      */
     public function scopeOverdue(Builder $query): void
     {
@@ -95,10 +87,6 @@ class Task extends Model
 
     /**
      * Scope a query to only include overdue tasks.
-     * 
-     * @param Builder $query 
-     * 
-     * @return void 
      */
     public function scopeNoAdminTasks(Builder $query): void
     {
@@ -111,10 +99,6 @@ class Task extends Model
 
     /**
      * Scope a query to only show open tasks.
-     * 
-     * @param Builder $query 
-     * 
-     * @return void 
      */
     public function scopeOpen(Builder $query): void
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,16 +4,16 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use App\Enums\Auth\Roles\Role;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
-use App\Enums\Auth\Roles\Role;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable, HasApiTokens;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -51,10 +51,8 @@ class User extends Authenticatable
 
     /**
      * Define the relationship with the User model.
-     * 
-     * @return HasMany
      */
-    public function tasks(): HasMany 
+    public function tasks(): HasMany
     {
         return $this->hasMany(Task::class);
     }
@@ -66,8 +64,6 @@ class User extends Authenticatable
 
     /**
      * Helper function to check if user has admin role.
-     * 
-     * @return bool
      */
     public function isAdmin(): bool
     {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,15 +1,15 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Foundation\Application;
 use App\Http\Middleware\AlwaysAcceptJson;
 use App\Http\Middleware\CheckTaskUpdateAuthorization;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -29,14 +29,14 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->renderable(function (NotFoundHttpException $e, Request $request) {
-            if ($request->wantsJson()) { 
+            if ($request->wantsJson()) {
                 return response()->json(['message' => 'Object not found'], 404);
-            } 
+            }
         });
-        $exceptions->renderable(function (AccessDeniedHttpException $e, Request  $request) {
-            if ($request->wantsJson()) { 
+        $exceptions->renderable(function (AccessDeniedHttpException $e, Request $request) {
+            if ($request->wantsJson()) {
                 return response()->json(['message' => 'Access denied'], 401);
-            } 
+            }
         });
 
     })->create();

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -4,7 +4,7 @@ use Knuckles\Scribe\Extracting\Strategies;
 
 return [
     // The HTML <title> for the generated documentation. If this is empty, Scribe will infer it from config('app.name').
-    'title' => "Mosquito",
+    'title' => 'Mosquito',
 
     // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
     'description' => 'Mosquito - A lightweight task api',
@@ -74,7 +74,7 @@ return [
     ],
 
     'external' => [
-        'html_attributes' => []
+        'html_attributes' => [],
     ],
 
     'try_it_out' => [
@@ -122,7 +122,7 @@ return [
     ],
 
     // Text to place in the "Introduction" section, right after the `description`. Markdown and HTML are supported.
-    'intro_text' => <<<INTRO
+    'intro_text' => <<<'INTRO'
 This documentation aims to provide all the information you need to work with our API.
 
 <aside>As you scroll, you'll see code examples for working with the API in different programming languages in the dark area to the right (or as part of the content on mobile).
@@ -224,8 +224,8 @@ INTRO
                 [
                     'Content-Type' => 'application/json',
                     'Accept' => 'application/json',
-                ]
-            ]
+                ],
+            ],
         ],
         'bodyParameters' => [
             Strategies\BodyParameters\GetFromFormRequest::class,
@@ -241,8 +241,8 @@ INTRO
             Strategies\Responses\UseResponseFileTag::class,
             [
                 Strategies\Responses\ResponseCalls::class,
-                ['only' => ['GET *']]
-            ]
+                ['only' => ['GET *']],
+            ],
         ],
         'responseFields' => [
             Strategies\ResponseFields\GetFromResponseFieldAttribute::class,

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -81,4 +81,24 @@ class TaskFactory extends Factory
             'state' => StateEnum::Todo->value,
         ]);
     }
+
+    /**
+     * Mark a project as in progress.
+     */
+    public function inProgess(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'state' => StateEnum::InProgess->value,
+        ]);
+    }
+
+    /**
+     * Mark a project as done.
+     */
+    public function done(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'state' => StateEnum::Done->value,
+        ]);
+    }
 }

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -2,11 +2,11 @@
 
 namespace Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Enums\StateEnum;
 use App\Models\Project;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Task>
@@ -24,8 +24,8 @@ class TaskFactory extends Factory
     {
         return [
             'title' => fake()->sentence,
-            'description' => fake()->words(asText:true),
-            'state' => fake()->randomElement(array_map(fn($case) => $case->value, StateEnum::cases())),
+            'description' => fake()->words(asText: true),
+            'state' => fake()->randomElement(array_map(fn ($case) => $case->value, StateEnum::cases())),
             // We have always a user.
             'user_id' => User::factory(),
         ];
@@ -54,34 +54,28 @@ class TaskFactory extends Factory
 
     /**
      * Mark a project as overdue.
-     * 
-     * @return static
      */
-    public function overdue(): static 
+    public function overdue(): static
     {
         return $this->state(fn (array $attributes) => [
-            'deadline' => now()->subDays(rand(1, 10))
+            'deadline' => now()->subDays(rand(1, 10)),
         ]);
     }
 
     /**
      * Mark a project as not overdue.
-     * 
-     * @return static
      */
-    public function notOverdue(): static 
+    public function notOverdue(): static
     {
         return $this->state(fn (array $attributes) => [
-            'deadline' => now()->addDays(rand(1, 10))
+            'deadline' => now()->addDays(rand(1, 10)),
         ]);
     }
 
     /**
      * Mark a project as todo.
-     * 
-     * @return static
      */
-    public function todo(): static 
+    public function todo(): static
     {
         return $this->state(fn (array $attributes) => [
             'state' => StateEnum::Todo->value,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,9 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Enums\Auth\Roles\Role;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use App\Enums\Auth\Roles\Role;
 use Illuminate\Support\Str;
 
 /**
@@ -46,10 +46,8 @@ class UserFactory extends Factory
 
     /**
      * Indicate the the user is an adminstrator.
-     * 
-     * @return static
      */
-    public function admin(): static 
+    public function admin(): static
     {
         return $this->state(fn (array $attributes) => [
             'role_id' => Role::ADMINISTRATOR->value,

--- a/database/migrations/2024_04_28_162823_add_role_id_to_user_table.php
+++ b/database/migrations/2024_04_28_162823_add_role_id_to_user_table.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\Auth\Roles\Role;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Enums\Auth\Roles\Role;
 
 return new class extends Migration
 {
@@ -23,7 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('role_id');            
+            $table->dropColumn('role_id');
         });
     }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use Illuminate\Database\Seeder;
 use App\Models\Project;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -24,14 +24,14 @@ class DatabaseSeeder extends Seeder
             ->create([
                 'name' => 'user1',
                 'email' => 'user1@example.com',
-                'password' => 'user1pw'
+                'password' => 'user1pw',
             ]);
 
         User::factory()
             ->create([
                 'name' => 'user2',
                 'email' => 'user2@example.com',
-                'password' => 'user2pw'
+                'password' => 'user2pw',
             ]);
 
         $user3 = User::factory()
@@ -39,9 +39,9 @@ class DatabaseSeeder extends Seeder
             ->create([
                 'name' => 'user3',
                 'email' => 'user3@example.com',
-                'password' => 'user3pw'
+                'password' => 'user3pw',
             ]);
-        
+
         Task::factory(100)
             ->notOverdue()
             ->for($user3)

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+	"preset": "laravel"
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,33 +1,33 @@
 <?php
 
-use App\Http\Controllers\Api\V1\Projects\ProjectDestroyController;
-use App\Http\Controllers\Api\V1\Projects\ProjectUpdateController;
-use App\Http\Controllers\Api\V1\Projects\ProjectIndexController;
-use App\Http\Controllers\Api\V1\Projects\ProjectStoreController;
-use App\Http\Controllers\Api\V1\Projects\ProjectTasksController;
-use App\Http\Controllers\Api\V1\Projects\ProjectShowController;
-use App\Http\Controllers\Api\V1\Tasks\TaskProjectsController;
-use App\Http\Controllers\Api\V1\Tasks\TaskOverdueController;
-use App\Http\Controllers\Api\V1\Tasks\TaskUpdateController;
-use App\Http\Controllers\Api\V1\Tasks\TaskIndexController;
-use App\Http\Controllers\Api\V1\Users\UserTasksController;
-use App\Http\Controllers\Api\V1\TaskController;
-use Illuminate\Auth\Middleware\Authenticate;
 use App\Enums\Auth\Token\ProjectTokenEnum;
-use App\Http\Controllers\AuthController;
 use App\Enums\Auth\Token\TaskTokenEnum;
 use App\Enums\Auth\Token\UserTokenEnum;
-use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V1\Projects\ProjectDestroyController;
+use App\Http\Controllers\Api\V1\Projects\ProjectIndexController;
+use App\Http\Controllers\Api\V1\Projects\ProjectShowController;
+use App\Http\Controllers\Api\V1\Projects\ProjectStoreController;
+use App\Http\Controllers\Api\V1\Projects\ProjectTasksController;
+use App\Http\Controllers\Api\V1\Projects\ProjectUpdateController;
+use App\Http\Controllers\Api\V1\TaskController;
+use App\Http\Controllers\Api\V1\Tasks\TaskIndexController;
+use App\Http\Controllers\Api\V1\Tasks\TaskOverdueController;
+use App\Http\Controllers\Api\V1\Tasks\TaskProjectsController;
+use App\Http\Controllers\Api\V1\Tasks\TaskUpdateController;
+use App\Http\Controllers\Api\V1\Users\UserTasksController;
+use App\Http\Controllers\AuthController;
+use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware(Authenticate::using('sanctum'));
 
 Route::group([
-    'prefix' => 'v1', 
+    'prefix' => 'v1',
     'namespace' => '\App\Http\Controllers\Api\V1',
-    'middleware' => ['deadline']
+    'middleware' => ['deadline'],
 ], function () {
     // Route::apiResource('tasks', TaskController::class)->middleware(['auth:sanctum']);
     Route::get('tasks/overdue', TaskOverdueController::class)
@@ -53,7 +53,7 @@ Route::group([
     Route::delete('tasks/{task}', [TaskController::class, 'destroy'])
         ->name('tasks.destroy')
         ->middleware(['auth:sanctum', TaskTokenEnum::Delete->toAbility()]);
-    
+
     Route::get('tasks/{task}/project', TaskProjectsController::class)
         ->name('tasks.project')
         ->middleware(['auth:sanctum', TaskTokenEnum::ReadTaskProjects->toAbility()]);
@@ -65,9 +65,9 @@ Route::group([
 
 // The project routes.
 Route::group([
-    'prefix' => 'v1', 
-    'namespace' => '\App\Http\Controllers\Api\V1', 
-    'middleware' => 'auth:sanctum'
+    'prefix' => 'v1',
+    'namespace' => '\App\Http\Controllers\Api\V1',
+    'middleware' => 'auth:sanctum',
 ], function () {
     Route::get('projects', ProjectIndexController::class)
         ->name('projects.index')
@@ -96,9 +96,9 @@ Route::group([
 
 // Get tasks for a specfic user.
 Route::group([
-    'prefix' => 'v1', 
+    'prefix' => 'v1',
     'namespace' => '\App\Http\Controllers\Api\V1',
-    'middleware' => ['auth:sanctum']
+    'middleware' => ['auth:sanctum'],
 ], function () {
     Route::get('users/{user}/tasks', UserTasksController::class)
         ->name('user.tasks')

--- a/tests/Feature/Api/V1/ProjectTest.php
+++ b/tests/Feature/Api/V1/ProjectTest.php
@@ -2,21 +2,22 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\ProjectTokenEnum;
-use Laravel\Sanctum\Sanctum;
-use Illuminate\Support\Arr;
 use App\Models\Project;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Arr;
+use Laravel\Sanctum\Sanctum;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class ProjectTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -67,7 +68,7 @@ class ProjectTest extends TestCase
         $response
             ->assertStatus(Response::HTTP_OK)
             ->assertExactJson([
-                'data' => Arr::only($project->toArray(), ['id', 'title'])
+                'data' => Arr::only($project->toArray(), ['id', 'title']),
             ]);
     }
 
@@ -158,7 +159,7 @@ class ProjectTest extends TestCase
             'projects',
             [
                 'id' => $project->id,
-                'title' => $expectedData
+                'title' => $expectedData,
             ]
         );
     }
@@ -254,9 +255,9 @@ class ProjectTest extends TestCase
                                 'description',
                                 'state',
                                 'project_id',
-                            ]
-                        ]
-                    ]
+                            ],
+                        ],
+                    ],
                 ]
             );
     }

--- a/tests/Feature/Api/V1/TaskAuthTest.php
+++ b/tests/Feature/Api/V1/TaskAuthTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
 use App\Enums\Auth\Token\TaskTokenEnum;
-use Laravel\Sanctum\Sanctum;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class TaskAuthTest extends TestCase
@@ -16,7 +16,7 @@ class TaskAuthTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * It should make sure that accessing the 
+     * It should make sure that accessing the
      * read route with incorrect ablities is denied.
      */
     public function test_that_read_route_forbidden(): void
@@ -37,7 +37,7 @@ class TaskAuthTest extends TestCase
     }
 
     /**
-     * It should make sure that accessing the 
+     * It should make sure that accessing the
      * read route is allowed.
      */
     public function test_that_read_route_is_allowed(): void

--- a/tests/Feature/Api/V1/TaskDeadlineTest.php
+++ b/tests/Feature/Api/V1/TaskDeadlineTest.php
@@ -2,19 +2,20 @@
 
 namespace Tests\Feature\Api\V1;
 
+use App\Enums\Auth\Token\TaskTokenEnum;
+use App\Enums\StateEnum;
+use App\Models\Task;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use App\Enums\Auth\Token\TaskTokenEnum;
 use Laravel\Sanctum\Sanctum;
-use App\Enums\StateEnum;
-use App\Models\User;
-use App\Models\Task;
 use Tests\TestCase;
 
 class TaskDeadlineTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -55,7 +56,7 @@ class TaskDeadlineTest extends TestCase
         $this->assertDatabaseHas(
             'tasks',
             array_merge(
-                $expectedData, 
+                $expectedData,
                 [
                     'id' => $task->id,
                     'deadline' => $deadline,

--- a/tests/Feature/Api/V1/TaskEventListenerTest.php
+++ b/tests/Feature/Api/V1/TaskEventListenerTest.php
@@ -36,10 +36,11 @@ class TaskEventListenerTest extends TestCase
         $tasks = Task::withoutEvents(function () use ($user) {
             return Task::factory(2)
                 ->overdue()
-                ->create([
-                    'user_id' => $user->id,
-                    'state' => StateEnum::Todo->value,
-                ]
+                ->create(
+                    [
+                        'user_id' => $user->id,
+                        'state' => StateEnum::Todo->value,
+                    ]
                 );
         });
 
@@ -48,11 +49,11 @@ class TaskEventListenerTest extends TestCase
 
         $response = $this->putJson(
             route('tasks.update', $tasks->first()),
-            ['state' => StateEnum::InProgess]
+            ['state' => StateEnum::InProgess->value]
         );
 
         // Assert.
-        $response->assertUnprocessable();
+        $response->assertForbidden();
 
         // The user is not an admin user and should not be able
         // to access overdue tasks.
@@ -91,7 +92,7 @@ class TaskEventListenerTest extends TestCase
             ['state' => StateEnum::InProgess]
         );
 
-        $response->assertUnprocessable();
+        $response->assertForbidden();
 
         // Assert
         Mail::assertSent(DeadlineBreachedEmail::class);

--- a/tests/Feature/Api/V1/TaskEventListenerTest.php
+++ b/tests/Feature/Api/V1/TaskEventListenerTest.php
@@ -2,23 +2,24 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\TaskTokenEnum;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Mail;
-use App\Mail\DeadlineBreachedEmail;
-use Laravel\Sanctum\Sanctum;
-use App\Events\TaskUpdating;
 use App\Enums\StateEnum;
+use App\Events\TaskUpdating;
+use App\Mail\DeadlineBreachedEmail;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class TaskEventListenerTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -39,7 +40,7 @@ class TaskEventListenerTest extends TestCase
                     'user_id' => $user->id,
                     'state' => StateEnum::Todo->value,
                 ]
-            );
+                );
         });
 
         // Act.
@@ -57,7 +58,7 @@ class TaskEventListenerTest extends TestCase
         // to access overdue tasks.
         $this->assertDatabaseHas('tasks', [
             'id' => $tasks->first()->id,
-            'state' => StateEnum::Todo->value
+            'state' => StateEnum::Todo->value,
         ]);
 
         Event::assertDispatched(TaskUpdating::class);
@@ -91,9 +92,8 @@ class TaskEventListenerTest extends TestCase
         );
 
         $response->assertUnprocessable();
-        
+
         // Assert
         Mail::assertSent(DeadlineBreachedEmail::class);
     }
 }
-

--- a/tests/Feature/Api/V1/TaskOverdueTest.php
+++ b/tests/Feature/Api/V1/TaskOverdueTest.php
@@ -2,20 +2,21 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\TaskTokenEnum;
-use Laravel\Sanctum\Sanctum;
 use App\Enums\StateEnum;
-use App\Models\User;
 use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class TaskOverdueTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -62,13 +63,12 @@ class TaskOverdueTest extends TestCase
                             'state',
                             'project_id',
                             'deadline',
-                        ]
-                    ]
+                        ],
+                    ],
                 ]
             )
             ->assertJson(
-                fn (AssertableJson $json) =>
-                $json->has('data', count($tasksOverdue))
+                fn (AssertableJson $json) => $json->has('data', count($tasksOverdue))
                     ->where('data.0.deadline', $mostOverdue->toJson())
             );
     }
@@ -198,21 +198,21 @@ class TaskOverdueTest extends TestCase
         $tasksUserOverdue = Task::factory(3)
             ->overdue()
             ->create(
-            [
-                'user_id' => $user->id,
-                'state' => StateEnum::InProgess,
-            ]
-        );
+                [
+                    'user_id' => $user->id,
+                    'state' => StateEnum::InProgess,
+                ]
+            );
 
         // Create tasks that are not overdue, but have a deadline.
         $tasksUserNotOverdue = Task::factory(5)
             ->notOverdue()
             ->create(
-            [
-                'user_id' => $user->id,
-                'state' => StateEnum::InProgess->value,
-            ]
-        );
+                [
+                    'user_id' => $user->id,
+                    'state' => StateEnum::InProgess->value,
+                ]
+            );
 
         // Act.
         Sanctum::actingAs($adminUser, [TaskTokenEnum::Update->value]);

--- a/tests/Feature/Api/V1/TaskOverdueTest.php
+++ b/tests/Feature/Api/V1/TaskOverdueTest.php
@@ -54,6 +54,7 @@ class TaskOverdueTest extends TestCase
 
         // Assert - HTTP status, structure, and most overdue task first.
         $response->assertOk()
+            ->assertJsonCount(count($tasksOverdue), 'data')
             ->assertJsonStructure(
                 [
                     'data' => [
@@ -100,19 +101,15 @@ class TaskOverdueTest extends TestCase
         // User
         $tasksUserOverdue = Task::factory(3)
             ->overdue()
-            ->create(
-                ['user_id' => $user->id]
-            );
+            ->create(['user_id' => $user->id]);
 
-        $tasksUserNotOverdue = Task::factory(2)
+        Task::factory(2)
             ->notOverdue()
             ->create(['user_id' => $user->id]);
 
         // OtherUser
-        $tasksOtherUser = Task::factory(5)
-            ->create(
-                ['user_id' => $otherUser->id]
-            );
+        Task::factory(5)
+            ->create(['user_id' => $otherUser->id]);
 
         Task::factory(2)
             ->notOverdue()
@@ -170,7 +167,7 @@ class TaskOverdueTest extends TestCase
         Sanctum::actingAs($adminUser, [TaskTokenEnum::Update->value]);
         $response = $this->putJson(
             route('tasks.update', $tasksUserOverdue[1]),
-            ['state' => StateEnum::Done]
+            ['state' => StateEnum::Done->value]
         );
 
         // Assert.
@@ -186,7 +183,112 @@ class TaskOverdueTest extends TestCase
     }
 
     /**
-     * Admin can not update tasks that are not overdue.
+     * Admin can update his own overdue tasks.
+     */
+    public function test_admin_can_update_overdue_tasks_for_himself(): void
+    {
+        // Arrange.
+        $adminUser = User::factory()->admin()->create();
+        $otherUser = User::factory()->create();
+        $user = User::factory()->create();
+
+        // Create overdue tasks.
+        $tasksAdminUserOverdue = Task::factory(3)
+            ->for($adminUser)
+            ->overdue()
+            ->create();
+
+        $tasksUserOverdue = Task::factory(3)
+            ->for($user)
+            ->overdue()
+            ->create(
+                [
+                    'state' => StateEnum::InProgess->value,
+                ]
+            );
+
+        // Create tasks that are not overdue, but have a deadline.
+        $tasksOtherUserOverdue = Task::factory(5)
+            ->for($otherUser)
+            ->overdue()
+            ->create();
+
+        // Act.
+        Sanctum::actingAs($adminUser, [TaskTokenEnum::Update->value]);
+
+        $response = $this->putJson(
+            route('tasks.update', $tasksAdminUserOverdue->first()),
+            ['state' => StateEnum::Done->value]
+        );
+        
+        // Assert.
+        $response->assertOk();
+
+        $this->assertDatabaseHas(
+            'tasks',
+            [
+                'id' => $tasksAdminUserOverdue->first()->id,
+                'state' => StateEnum::Done->value,
+            ]
+        );
+    }
+
+    /**
+     * Admin can update his own not overdue tasks.
+     */
+    public function test_admin_can_update_not_overdue_tasks_for_himself(): void
+    {
+        // Arrange.
+        $adminUser = User::factory()->admin()->create();
+        $otherUser = User::factory()->create();
+        $user = User::factory()->create();
+
+        // Create overdue tasks.
+        $tasksAdminUserNotOverdue = Task::factory(3)
+            ->for($adminUser)
+            ->notOverdue()
+            ->create(
+                ['state' => StateEnum::InProgess->value]
+            );
+
+        $tasksUserOverdue = Task::factory(3)
+            ->for($user)
+            ->overdue()
+            ->create(
+                [
+                    'state' => StateEnum::InProgess->value,
+                ]
+            );
+
+        // Create tasks that are not overdue, but have a deadline.
+        $tasksOtherUserOverdue = Task::factory(5)
+            ->for($otherUser)
+            ->overdue()
+            ->create();
+
+        // Act.
+        Sanctum::actingAs($adminUser, [TaskTokenEnum::Update->value]);
+
+        $response = $this->putJson(
+            route('tasks.update', $tasksAdminUserNotOverdue->first()),
+            ['state' => StateEnum::Done->value]
+        );
+        
+        // Assert.
+        $response->assertOk();
+
+        $this->assertDatabaseHas(
+            'tasks',
+            [
+                'id' => $tasksAdminUserNotOverdue->first()->id,
+                'state' => StateEnum::Done->value,
+            ]
+        );
+    }
+
+
+    /**
+     * Admin can not update tasks that are not overdue for other users.
      */
     public function test_admin_can_not_update_not_overdue_tasks_for_users(): void
     {

--- a/tests/Feature/Api/V1/TaskOverdueTest.php
+++ b/tests/Feature/Api/V1/TaskOverdueTest.php
@@ -220,7 +220,7 @@ class TaskOverdueTest extends TestCase
             route('tasks.update', $tasksAdminUserOverdue->first()),
             ['state' => StateEnum::Done->value]
         );
-        
+
         // Assert.
         $response->assertOk();
 
@@ -273,7 +273,7 @@ class TaskOverdueTest extends TestCase
             route('tasks.update', $tasksAdminUserNotOverdue->first()),
             ['state' => StateEnum::Done->value]
         );
-        
+
         // Assert.
         $response->assertOk();
 
@@ -285,7 +285,6 @@ class TaskOverdueTest extends TestCase
             ]
         );
     }
-
 
     /**
      * Admin can not update tasks that are not overdue for other users.

--- a/tests/Feature/Api/V1/TaskProjectTest.php
+++ b/tests/Feature/Api/V1/TaskProjectTest.php
@@ -2,21 +2,22 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\TaskTokenEnum;
 use App\Enums\StateEnum;
-use Laravel\Sanctum\Sanctum;
 use App\Models\Project;
-use App\Models\User;
 use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class TaskProjectTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -29,7 +30,7 @@ class TaskProjectTest extends TestCase
         $user = User::factory()->create();
         $otherUser = User::factory()->create();
 
-        $projects =  Project::factory(3)->create();
+        $projects = Project::factory(3)->create();
 
         $tasks = Task::factory(3)->create([
             'project_id' => $projects[0]->id,
@@ -86,7 +87,7 @@ class TaskProjectTest extends TestCase
             ]
         );
 
-        // Assert. 
+        // Assert.
         $response->assertCreated();
 
         $this->assertDatabaseHas(
@@ -113,11 +114,11 @@ class TaskProjectTest extends TestCase
                 'description' => 'a cool description',
                 'state' => StateEnum::Todo,
                 'deadline' => now()->addDays(10),
-                'project_id' => 666
+                'project_id' => 666,
             ]
         );
 
-        // Assert. 
+        // Assert.
         $response->assertUnprocessable();
     }
 
@@ -148,7 +149,7 @@ class TaskProjectTest extends TestCase
             ]
         );
 
-        // Assert. 
+        // Assert.
         $response->assertOk();
 
         $this->assertDatabaseHas(
@@ -183,7 +184,7 @@ class TaskProjectTest extends TestCase
             ]
         );
 
-        // Assert. 
+        // Assert.
         $response->assertUnprocessable();
     }
 }

--- a/tests/Feature/Api/V1/TaskProjectTest.php
+++ b/tests/Feature/Api/V1/TaskProjectTest.php
@@ -81,7 +81,7 @@ class TaskProjectTest extends TestCase
             $expectedData = [
                 'title' => 'my title',
                 'description' => 'a cool description',
-                'state' => StateEnum::Todo,
+                'state' => StateEnum::Todo->value,
                 'deadline' => now()->addDays(10),
                 'project_id' => $project->id,
             ]

--- a/tests/Feature/Api/V1/TaskTest.php
+++ b/tests/Feature/Api/V1/TaskTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\TaskTokenEnum;
-use Laravel\Sanctum\Sanctum;
-use Illuminate\Support\Arr;
 use App\Enums\StateEnum;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Arr;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class TaskTest extends TestCase
@@ -21,6 +21,7 @@ class TaskTest extends TestCase
 
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 
@@ -83,7 +84,7 @@ class TaskTest extends TestCase
         $response
             ->assertOk()
             ->assertJson([
-                'data' => Arr::only($task->toArray(), ['title', 'state', 'description'])
+                'data' => Arr::only($task->toArray(), ['title', 'state', 'description']),
             ]);
     }
 
@@ -116,8 +117,8 @@ class TaskTest extends TestCase
             ->assertJsonCount(10, 'data')
             ->assertJson([
                 'data' => [
-                    Arr::only($tasks->toArray(), ['title', 'state', 'description'])
-                ]
+                    Arr::only($tasks->toArray(), ['title', 'state', 'description']),
+                ],
             ]);
     }
 
@@ -178,7 +179,7 @@ class TaskTest extends TestCase
     }
 
     /**
-     * It should update a task. 
+     * It should update a task.
      */
     public function test_should_update_a_task(): void
     {
@@ -218,9 +219,9 @@ class TaskTest extends TestCase
     }
 
     /**
-     * It should not be able to update a task if the max length of the title is 
+     * It should not be able to update a task if the max length of the title is
      * surpassed.
-     * 
+     *
      * Exam Additional Part.
      */
     public function test_should_not_be_able_to_update_a_task_if_surpassing_title_limit(): void
@@ -245,7 +246,7 @@ class TaskTest extends TestCase
     }
 
     /**
-     * It should delete a task. 
+     * It should delete a task.
      */
     public function test_should_delete_a_task(): void
     {

--- a/tests/Feature/Api/V1/UserTasksTest.php
+++ b/tests/Feature/Api/V1/UserTasksTest.php
@@ -2,18 +2,19 @@
 
 namespace Tests\Feature\Api\V1;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use App\Enums\Auth\Token\UserTokenEnum;
-use Laravel\Sanctum\Sanctum;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class UserTasksTest extends TestCase
 {
     // We must use this trait to create tables.
     use RefreshDatabase;
+
     // To use faker within this test class.
     use WithFaker;
 


### PR DESCRIPTION
This fix contains all improvements that entail the correct solution to the task of designing a task API that was given to me by Smake IT.

* Usage of laravel pint (mandatory).
* Correct middleware to authorize overdue tasks by generating an event if accessing overdue tasks.
* Avoidance of fillable fields in the task model.